### PR TITLE
Fix issues storing mp_id when using MariaDB

### DIFF
--- a/django_mercadopago/migrations/0018_payment_mpid_biginteger.py
+++ b/django_mercadopago/migrations/0018_payment_mpid_biginteger.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mp', '0017_preference_quantity'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='payment',
+            name='mp_id',
+            field=models.BigIntegerField(unique=True, verbose_name='mp id'),
+        ),
+    ]

--- a/django_mercadopago/models.py
+++ b/django_mercadopago/models.py
@@ -346,7 +346,7 @@ class Payment(models.Model):
     A payment received, related to a preference.
     """
 
-    mp_id = models.IntegerField(
+    mp_id = models.BigIntegerField(
         _('mp id'),
         unique=True,
     )


### PR DESCRIPTION
Since IntegerField has a limit of 2^31 on MariaDB, that doesn't work for saving the external ids for Payments. Use BigInteger instead.

Fixes #8