### PR TITLE
Fix bug when running multiple databases migrations

### DIFF
--- a/django_mercadopago/migrations/0002_auto_20150923_2328.py
+++ b/django_mercadopago/migrations/0002_auto_20150923_2328.py
@@ -5,26 +5,27 @@ from django.db import models, migrations
 
 
 def fake_data(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     Account = apps.get_model('mp', 'Account')
     Notification = apps.get_model('mp', 'Notification')
     Payment = apps.get_model('mp', 'Payment')
 
     # Only generate this if we have actual data in the DB:
-    if Account.objects.count() + Notification.objects.count() + \
-       Payment.objects.count() == 0:
+    if Account.objects.using(db_alias).count() + Notification.objects.using(db_alias).count() + \
+       Payment.objects.using(db_alias).count() == 0:
         return
 
-    account = Account.objects.create(
+    account = Account.objects.using(db_alias).create(
         name="Auto-migrated",
         slug="_",
         app_id="_",
         secret_key="_",
         sandbox=True,
     )
-    Notification.objects.update(owner=account)
+    Notification.objects.using(db_alias).update(owner=account)
 
-    for payment in Payment.objects.all():
-        payment.notification = Notification.objects.create(
+    for payment in Payment.objects.using(db_alias).all():
+        payment.notification = Notification.objects.using(db_alias).create(
             id=-payment.id,
             owner=account,
             topic="f",


### PR DESCRIPTION
Fix https://github.com/WhyNotHugo/django-mercadopago/issues/23.

For test it, for example, add a `DATABASES` config:
``` python
DATABASES = {
    'another': {
        'ENGINE': 'django.db.backends.sqlite3',
        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
    },
    'default': {
        # your configs
    },
}
```
then run 
``` bash
python manage.py migrate --database another
```